### PR TITLE
Add badges and curator gamification features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__
 package-lock.json
 dist
 **/.DS_Store
+**/.pytest_cache/
+**/.venv/
 
 # Test artifacts
 .pytest_cache/

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -89,10 +89,13 @@ def create_app():
     from app.routes.user_profile import user_profile_bp
     from app.routes.aura import aura_bp
     from app.routes.search import search_bp
+    from app.routes.badges import badges_bp, curator_bp
     app.register_blueprint(auth_bp, url_prefix='/api/v1/auth')
     app.register_blueprint(content_bp, url_prefix='/api/v1/content')
     app.register_blueprint(user_profile_bp, url_prefix='/api/v1/users')
     app.register_blueprint(aura_bp, url_prefix='/api/v1/aura')
     app.register_blueprint(search_bp, url_prefix='/api/v1/search')
+    app.register_blueprint(badges_bp, url_prefix='/api/v1/badges')
+    app.register_blueprint(curator_bp, url_prefix='/api/v1/curator')
     
     return app

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -18,7 +18,7 @@ def init_db(app):
     session_factory = sessionmaker(bind=engine)
     
     # Import all models to ensure they're registered
-    from app.models import user, content, share
+    from app.models import user, content, share, badge
     
     # Create all tables
     Base.metadata.create_all(engine)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,10 @@
 # Models package
 from app.models.user import User
 from app.models.content import Movie, Album, Game, Book, Location, MovieType, GameDifficulty
+from app.models.badge import Badge, UserBadge, CuratorLevel
 
-__all__ = ['User', 'Movie', 'Album', 'Game', 'Book', 'Location', 'MovieType', 'GameDifficulty']
+__all__ = [
+    'User',
+    'Movie', 'Album', 'Game', 'Book', 'Location', 'MovieType', 'GameDifficulty',
+    'Badge', 'UserBadge', 'CuratorLevel',
+]

--- a/backend/app/models/badge.py
+++ b/backend/app/models/badge.py
@@ -1,0 +1,147 @@
+from datetime import datetime
+from sqlalchemy import Column, String, DateTime, Text, ForeignKey, Integer, Boolean
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import relationship
+import uuid
+from app.database import Base
+
+
+class Badge(Base):
+    """Badge catalog — all available badges in the system"""
+    __tablename__ = 'badges'
+
+    id = Column(String, primary_key=True, default=lambda: f"b_{uuid.uuid4().hex[:12]}")
+    name = Column(String(100), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    icon = Column(String(100), nullable=True)          # icon identifier / emoji
+    rarity = Column(String(20), nullable=False)        # common | rare | epic | legendary
+    category = Column(String(30), nullable=False)      # early | completionist | social | streak | special
+    max_progress = Column(Integer, nullable=False, default=1)  # 1 = binary unlock
+
+    # back-ref populated by UserBadge
+    user_badges = relationship('UserBadge', back_populates='badge')
+
+    def to_dict(self, unlocked: bool = False, unlocked_date=None, progress: int = 0):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'icon': self.icon,
+            'rarity': self.rarity,
+            'category': self.category,
+            'maxProgress': self.max_progress,
+            'unlocked': unlocked,
+            'unlockedDate': unlocked_date.isoformat() if unlocked_date else None,
+            'progress': progress,
+        }
+
+    def __repr__(self):
+        return f'<Badge {self.name}>'
+
+
+class UserBadge(Base):
+    """Tracks which badges a user has earned and their progress"""
+    __tablename__ = 'user_badges'
+
+    id = Column(String, primary_key=True, default=lambda: f"ub_{uuid.uuid4().hex[:12]}")
+    user_id = Column(String, ForeignKey('users.user_id'), nullable=False, index=True)
+    badge_id = Column(String, ForeignKey('badges.id'), nullable=False, index=True)
+    unlocked = Column(Boolean, default=False, nullable=False)
+    progress = Column(Integer, default=0, nullable=False)
+    unlocked_at = Column(DateTime, nullable=True)
+
+    badge = relationship('Badge', back_populates='user_badges')
+    user = relationship('User', backref='user_badges')
+
+    def __repr__(self):
+        return f'<UserBadge user={self.user_id} badge={self.badge_id}>'
+
+
+class CuratorLevel(Base):
+    """XP-based curator progression levels"""
+    __tablename__ = 'curator_levels'
+
+    level = Column(Integer, primary_key=True)
+    name = Column(String(50), nullable=False)
+    xp_required = Column(Integer, nullable=False)
+    rewards = Column(JSON, nullable=True)   # list of reward strings
+    color = Column(String(7), nullable=True)  # hex e.g. #A855F7
+
+    def to_dict(self):
+        return {
+            'level': self.level,
+            'name': self.name,
+            'xpRequired': self.xp_required,
+            'rewards': self.rewards or [],
+            'color': self.color,
+        }
+
+    def __repr__(self):
+        return f'<CuratorLevel {self.level} {self.name}>'
+
+
+# ──────────────────────────────────────────────────────────────────
+# Seed data helpers
+# ──────────────────────────────────────────────────────────────────
+
+SEED_BADGES = [
+    # early
+    {'name': 'First Share', 'description': 'Share your first piece of content.', 'icon': '🌱', 'rarity': 'common', 'category': 'early', 'max_progress': 1},
+    {'name': 'Early Adopter', 'description': 'Join VibeCheck in its first month.', 'icon': '⚡', 'rarity': 'rare', 'category': 'early', 'max_progress': 1},
+    # completionist
+    {'name': 'Film Buff', 'description': 'Share 10 movies.', 'icon': '🎬', 'rarity': 'common', 'category': 'completionist', 'max_progress': 10},
+    {'name': 'Audiophile', 'description': 'Share 10 albums.', 'icon': '🎵', 'rarity': 'common', 'category': 'completionist', 'max_progress': 10},
+    {'name': 'Bookworm', 'description': 'Share 10 books.', 'icon': '📚', 'rarity': 'common', 'category': 'completionist', 'max_progress': 10},
+    {'name': 'Gamer', 'description': 'Share 10 games.', 'icon': '🎮', 'rarity': 'common', 'category': 'completionist', 'max_progress': 10},
+    {'name': 'Wanderer', 'description': 'Share 10 travel locations.', 'icon': '✈️', 'rarity': 'common', 'category': 'completionist', 'max_progress': 10},
+    {'name': 'All-Rounder', 'description': 'Share at least one item in every category.', 'icon': '🌈', 'rarity': 'rare', 'category': 'completionist', 'max_progress': 5},
+    # social
+    {'name': 'Social Butterfly', 'description': 'Receive your first aura match.', 'icon': '🦋', 'rarity': 'common', 'category': 'social', 'max_progress': 1},
+    {'name': 'Trendsetter', 'description': 'Have 10 posts liked by others.', 'icon': '🔥', 'rarity': 'rare', 'category': 'social', 'max_progress': 10},
+    # streak
+    {'name': '7-Day Streak', 'description': 'Share content 7 days in a row.', 'icon': '📅', 'rarity': 'rare', 'category': 'streak', 'max_progress': 7},
+    {'name': '30-Day Streak', 'description': 'Share content 30 days in a row.', 'icon': '🗓️', 'rarity': 'epic', 'category': 'streak', 'max_progress': 30},
+    # special
+    {'name': 'Tastemaker', 'description': 'Reach Curator Level 5.', 'icon': '🏆', 'rarity': 'epic', 'category': 'special', 'max_progress': 1},
+    {'name': 'Legend', 'description': 'Reach Curator Level 10.', 'icon': '👑', 'rarity': 'legendary', 'category': 'special', 'max_progress': 1},
+]
+
+SEED_CURATOR_LEVELS = [
+    {'level': 1, 'name': 'Newcomer',     'xp_required': 0,    'rewards': ['Access to basic features'],                  'color': '#6B7280'},
+    {'level': 2, 'name': 'Explorer',     'xp_required': 100,  'rewards': ['Unlock aura matching'],                       'color': '#3B82F6'},
+    {'level': 3, 'name': 'Curator',      'xp_required': 300,  'rewards': ['Custom aura colors'],                         'color': '#10B981'},
+    {'level': 4, 'name': 'Connoisseur',  'xp_required': 700,  'rewards': ['Profile badge frame'],                        'color': '#F59E0B'},
+    {'level': 5, 'name': 'Tastemaker',   'xp_required': 1500, 'rewards': ['Exclusive Tastemaker badge', 'Priority in aura matches'], 'color': '#8B5CF6'},
+    {'level': 6, 'name': 'Visionary',    'xp_required': 3000, 'rewards': ['Visionary profile border'],                   'color': '#EC4899'},
+    {'level': 7, 'name': 'Luminary',     'xp_required': 5000, 'rewards': ['Luminary aura effect'],                       'color': '#EF4444'},
+    {'level': 8, 'name': 'Sage',         'xp_required': 8000, 'rewards': ['Sage curator title'],                         'color': '#F97316'},
+    {'level': 9, 'name': 'Oracle',       'xp_required': 12000,'rewards': ['Oracle discovery feed boost'],                 'color': '#14B8A6'},
+    {'level': 10,'name': 'Legend',       'xp_required': 20000,'rewards': ['Legend badge', 'Permanent hall of fame entry'],'color': '#EAB308'},
+]
+
+
+def seed_badges_and_levels(db):
+    """Insert default badges and curator levels if they don't exist yet."""
+    # Badges
+    for data in SEED_BADGES:
+        exists = db.query(Badge).filter_by(name=data['name']).first()
+        if not exists:
+            badge = Badge(
+                id=f"b_{uuid.uuid4().hex[:12]}",
+                name=data['name'],
+                description=data['description'],
+                icon=data['icon'],
+                rarity=data['rarity'],
+                category=data['category'],
+                max_progress=data['max_progress'],
+            )
+            db.add(badge)
+
+    # Curator levels
+    for data in SEED_CURATOR_LEVELS:
+        exists = db.query(CuratorLevel).filter_by(level=data['level']).first()
+        if not exists:
+            lvl = CuratorLevel(**data)
+            db.add(lvl)
+
+    db.commit()

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,4 +1,5 @@
 # Routes package
 from app.routes.auth import auth_bp
+from app.routes.badges import badges_bp, curator_bp
 
-__all__ = ['auth_bp']
+__all__ = ['auth_bp', 'badges_bp', 'curator_bp']

--- a/backend/app/routes/badges.py
+++ b/backend/app/routes/badges.py
@@ -1,0 +1,548 @@
+"""
+Badges & Gamification routes
+
+Blueprints:
+  badges_bp  → /api/v1/badges
+  curator_bp → /api/v1/curator
+"""
+
+from datetime import datetime, timedelta
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity, verify_jwt_in_request
+from sqlalchemy import func
+from typing import cast
+
+from app.database import get_db
+from app.models.user import User
+from app.models.share import Share
+from app.models.badge import Badge, UserBadge, CuratorLevel, seed_badges_and_levels
+
+badges_bp = Blueprint('badges', __name__)
+curator_bp = Blueprint('curator', __name__)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Internal helpers
+# ──────────────────────────────────────────────────────────────────
+
+XP_PER_SHARE = 10  # base XP awarded for each share
+
+
+def _compute_streak(share_dates: list[datetime]) -> int:
+    """Return current consecutive-day streak from a list of share datetimes."""
+    if not share_dates:
+        return 0
+    # Deduplicate to dates only
+    days = sorted({d.date() for d in share_dates}, reverse=True)
+    today = datetime.utcnow().date()
+    # Start counting only if the user shared today or yesterday
+    if days[0] < today - timedelta(days=1):
+        return 0
+    streak = 1
+    for i in range(1, len(days)):
+        if days[i - 1] - days[i] == timedelta(days=1):
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def _current_level(total_xp: int, levels: list) -> dict:
+    """Return the highest level the user has reached."""
+    current = levels[0]
+    for lvl in levels:
+        if total_xp >= lvl.xp_required:
+            current = lvl
+        else:
+            break
+    return current
+
+
+def _evaluate_badges(db, user_id: str, shares) -> dict[str, dict]:
+    """
+    Compute per-badge progress for a user and upsert UserBadge rows.
+    Returns a dict keyed by badge.id → {unlocked, progress, unlocked_at}.
+    """
+    # Category counts
+    category_counts: dict[str, int] = {}
+    for s in shares:
+        category_counts[s.category] = category_counts.get(s.category, 0) + 1
+
+    total = len(shares)
+    streak = _compute_streak([s.created_at for s in shares])
+    categories_used = len(category_counts)
+
+    # Define thresholds per badge name
+    progress_map: dict[str, int] = {
+        'First Share':     min(total, 1),
+        'Early Adopter':   1,          # always unlocked if seeded during beta
+        'Film Buff':       min(category_counts.get('cinema', 0), 10),
+        'Audiophile':      min(category_counts.get('music', 0), 10),
+        'Bookworm':        min(category_counts.get('books', 0), 10),
+        'Gamer':           min(category_counts.get('games', 0), 10),
+        'Wanderer':        min(category_counts.get('travel', 0), 10),
+        'All-Rounder':     min(categories_used, 5),
+        'Social Butterfly': 0,          # unlock handled externally (aura matches)
+        'Trendsetter':     0,           # unlock handled externally (likes)
+        '7-Day Streak':    min(streak, 7),
+        '30-Day Streak':   min(streak, 30),
+        'Tastemaker':      0,           # unlock handled by curator level check below
+        'Legend':          0,
+    }
+
+    # Fetch all badges & existing user_badges in one go
+    all_badges = db.query(Badge).all()
+    existing_ubs: dict[str, UserBadge] = {
+        ub.badge_id: ub
+        for ub in db.query(UserBadge).filter_by(user_id=user_id).all()
+    }
+
+    result: dict[str, dict] = {}
+    for badge in all_badges:
+        progress = progress_map.get(badge.name, 0)
+        unlocked = progress >= badge.max_progress
+
+        ub = existing_ubs.get(badge.id)
+        if ub is None:
+            ub = UserBadge(user_id=user_id, badge_id=badge.id)
+            db.add(ub)
+
+        # Only set unlocked_at once
+        if unlocked and not ub.unlocked:
+            ub.unlocked_at = datetime.utcnow()
+        ub.progress = progress
+        ub.unlocked = unlocked
+
+        result[badge.id] = {
+            'unlocked': ub.unlocked,
+            'progress': ub.progress,
+            'unlocked_at': ub.unlocked_at,
+        }
+
+    db.commit()
+    return result
+
+
+def _build_curator_stats(db, user: User) -> dict:
+    """Compute and return curator stats for the given user."""
+    shares = db.query(Share).filter_by(user_id=user.user_id).all()
+    total_shares = len(shares)
+    total_xp = total_shares * XP_PER_SHARE
+
+    levels = db.query(CuratorLevel).order_by(CuratorLevel.level).all()
+    if not levels:
+        seed_badges_and_levels(db)
+        levels = db.query(CuratorLevel).order_by(CuratorLevel.level).all()
+
+    current_level_obj = _current_level(total_xp, levels)
+
+    # XP to next level
+    next_levels = [l for l in levels if l.xp_required > total_xp]
+    xp_to_next = (next_levels[0].xp_required - total_xp) if next_levels else 0
+
+    streak = _compute_streak([s.created_at for s in shares])
+
+    # Category breakdown
+    category_counts: dict[str, int] = {}
+    for s in shares:
+        category_counts[s.category] = category_counts.get(s.category, 0) + 1
+
+    # Badges
+    badge_state = _evaluate_badges(db, user.user_id, shares)
+    all_badges = db.query(Badge).all()
+    earned_badges = [
+        badge.to_dict(
+            unlocked=badge_state[badge.id]['unlocked'],
+            unlocked_date=badge_state[badge.id]['unlocked_at'],
+            progress=badge_state[badge.id]['progress'],
+        )
+        for badge in all_badges
+        if badge.id in badge_state and badge_state[badge.id]['unlocked']
+    ]
+
+    # Tastemaker / Legend level check
+    if current_level_obj.level >= 10:
+        for badge in all_badges:
+            if badge.name == 'Legend' and badge.id in badge_state:
+                ub = db.query(UserBadge).filter_by(user_id=user.user_id, badge_id=badge.id).first()
+                if ub and not ub.unlocked:
+                    ub.unlocked = True
+                    ub.unlocked_at = datetime.utcnow()
+                    ub.progress = 1
+                    db.commit()
+    if current_level_obj.level >= 5:
+        for badge in all_badges:
+            if badge.name == 'Tastemaker' and badge.id in badge_state:
+                ub = db.query(UserBadge).filter_by(user_id=user.user_id, badge_id=badge.id).first()
+                if ub and not ub.unlocked:
+                    ub.unlocked = True
+                    ub.unlocked_at = datetime.utcnow()
+                    ub.progress = 1
+                    db.commit()
+
+    return {
+        'userId': user.user_id,
+        'username': user.username,
+        'totalShares': total_shares,
+        'totalXP': total_xp,
+        'currentLevel': current_level_obj.level,
+        'currentLevelName': current_level_obj.name,
+        'xpToNextLevel': xp_to_next,
+        'streakDays': streak,
+        'categoryBreakdown': category_counts,
+        'badges': earned_badges,
+        'badgeCount': len(earned_badges),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────
+# BADGES endpoints
+# ──────────────────────────────────────────────────────────────────
+
+@badges_bp.route('', methods=['GET'])
+def get_all_badges():
+    """
+    Get all available badges
+    ---
+    tags:
+      - Badges & Gamification
+    parameters:
+      - name: rarity
+        in: query
+        type: string
+        enum: [common, rare, epic, legendary]
+        description: Filter by rarity
+      - name: category
+        in: query
+        type: string
+        enum: [early, completionist, social, streak, special]
+        description: Filter by category
+    responses:
+      200:
+        description: List of all badges
+        schema:
+          type: object
+          properties:
+            badges:
+              type: array
+            total:
+              type: integer
+      400:
+        description: Bad request
+    """
+    try:
+        db = get_db()
+
+        # Seed if empty
+        count = db.query(func.count(Badge.id)).scalar()
+        if count == 0:
+            seed_badges_and_levels(db)
+
+        rarity = request.args.get('rarity')
+        category = request.args.get('category')
+
+        valid_rarities = {'common', 'rare', 'epic', 'legendary'}
+        valid_categories = {'early', 'completionist', 'social', 'streak', 'special'}
+
+        if rarity and rarity not in valid_rarities:
+            return jsonify({
+                'error': 'Bad Request',
+                'message': f'Invalid rarity. Must be one of: {", ".join(valid_rarities)}'
+            }), 400
+
+        if category and category not in valid_categories:
+            return jsonify({
+                'error': 'Bad Request',
+                'message': f'Invalid category. Must be one of: {", ".join(valid_categories)}'
+            }), 400
+
+        query = db.query(Badge)
+        if rarity:
+            query = query.filter_by(rarity=rarity)
+        if category:
+            query = query.filter_by(category=category)
+
+        badges = query.all()
+
+        # If the caller is authenticated, enrich with their unlock state
+        user_badge_map: dict[str, UserBadge] = {}
+        try:
+            verify_jwt_in_request(optional=True)
+            current_user_id = get_jwt_identity()
+            if current_user_id:
+                ubs = db.query(UserBadge).filter_by(user_id=current_user_id).all()
+                user_badge_map = {ub.badge_id: ub for ub in ubs}
+        except Exception:
+            pass
+
+        result = []
+        for badge in badges:
+            ub = user_badge_map.get(badge.id)
+            result.append(badge.to_dict(
+                unlocked=ub.unlocked if ub else False,
+                unlocked_date=ub.unlocked_at if ub else None,
+                progress=ub.progress if ub else 0,
+            ))
+
+        return jsonify({
+            'badges': result,
+            'total': len(result),
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500
+
+
+@badges_bp.route('/user', methods=['GET'])
+@jwt_required()
+def get_current_user_badges():
+    """
+    Get current user's badges with unlock status and progress
+    ---
+    tags:
+      - Badges & Gamification
+    security:
+      - Bearer: []
+    responses:
+      200:
+        description: User's badge collection
+        schema:
+          type: object
+          properties:
+            badges:
+              type: array
+            earnedCount:
+              type: integer
+            totalCount:
+              type: integer
+      401:
+        description: Unauthorized
+    """
+    try:
+        current_user_id = get_jwt_identity()
+        db = get_db()
+
+        user = db.query(User).filter_by(user_id=current_user_id).first()
+        if not user:
+            return jsonify({'error': 'Not Found', 'message': 'User not found'}), 404
+
+        # Seed if needed
+        count = db.query(func.count(Badge.id)).scalar()
+        if count == 0:
+            seed_badges_and_levels(db)
+
+        shares = db.query(Share).filter_by(user_id=current_user_id).all()
+        badge_state = _evaluate_badges(db, current_user_id, shares)
+
+        all_badges = db.query(Badge).all()
+        result = [
+            badge.to_dict(
+                unlocked=badge_state.get(badge.id, {}).get('unlocked', False),
+                unlocked_date=badge_state.get(badge.id, {}).get('unlocked_at'),
+                progress=badge_state.get(badge.id, {}).get('progress', 0),
+            )
+            for badge in all_badges
+        ]
+
+        earned = sum(1 for b in result if b['unlocked'])
+        return jsonify({
+            'badges': result,
+            'earnedCount': earned,
+            'totalCount': len(result),
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500
+
+
+@badges_bp.route('/user/<user_id>', methods=['GET'])
+def get_user_badges_by_id(user_id: str):
+    """
+    Get a specific user's badges
+    ---
+    tags:
+      - Badges & Gamification
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        type: string
+        description: Target user ID
+    responses:
+      200:
+        description: User's badge collection
+      404:
+        description: User not found
+    """
+    try:
+        db = get_db()
+
+        user = db.query(User).filter_by(user_id=user_id).first()
+        if not user:
+            return jsonify({'error': 'Not Found', 'message': 'User not found'}), 404
+
+        count = db.query(func.count(Badge.id)).scalar()
+        if count == 0:
+            seed_badges_and_levels(db)
+
+        shares = db.query(Share).filter_by(user_id=user_id).all()
+        badge_state = _evaluate_badges(db, user_id, shares)
+
+        all_badges = db.query(Badge).all()
+        result = [
+            badge.to_dict(
+                unlocked=badge_state.get(badge.id, {}).get('unlocked', False),
+                unlocked_date=badge_state.get(badge.id, {}).get('unlocked_at'),
+                progress=badge_state.get(badge.id, {}).get('progress', 0),
+            )
+            for badge in all_badges
+        ]
+
+        earned = sum(1 for b in result if b['unlocked'])
+        return jsonify({
+            'userId': user_id,
+            'username': user.username,
+            'badges': result,
+            'earnedCount': earned,
+            'totalCount': len(result),
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500
+
+
+# ──────────────────────────────────────────────────────────────────
+# CURATOR endpoints
+# ──────────────────────────────────────────────────────────────────
+
+@curator_bp.route('/stats', methods=['GET'])
+@jwt_required()
+def get_curator_stats():
+    """
+    Get current user's curator statistics
+    ---
+    tags:
+      - Badges & Gamification
+    security:
+      - Bearer: []
+    responses:
+      200:
+        description: Curator statistics
+        schema:
+          type: object
+          properties:
+            userId:
+              type: string
+            totalShares:
+              type: integer
+            totalXP:
+              type: integer
+            currentLevel:
+              type: integer
+            currentLevelName:
+              type: string
+            xpToNextLevel:
+              type: integer
+            streakDays:
+              type: integer
+            categoryBreakdown:
+              type: object
+            badges:
+              type: array
+            badgeCount:
+              type: integer
+      401:
+        description: Unauthorized
+    """
+    try:
+        current_user_id = get_jwt_identity()
+        db = get_db()
+
+        user = db.query(User).filter_by(user_id=current_user_id).first()
+        if not user:
+            return jsonify({'error': 'Not Found', 'message': 'User not found'}), 404
+
+        # Ensure levels exist
+        lvl_count = db.query(func.count(CuratorLevel.level)).scalar()
+        if lvl_count == 0:
+            seed_badges_and_levels(db)
+
+        stats = _build_curator_stats(db, user)
+        return jsonify(stats), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500
+
+
+@curator_bp.route('/stats/<user_id>', methods=['GET'])
+def get_curator_stats_by_user_id(user_id: str):
+    """
+    Get a specific user's curator statistics
+    ---
+    tags:
+      - Badges & Gamification
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        type: string
+        description: Target user ID
+    responses:
+      200:
+        description: Curator statistics
+      404:
+        description: User not found
+    """
+    try:
+        db = get_db()
+
+        user = db.query(User).filter_by(user_id=user_id).first()
+        if not user:
+            return jsonify({'error': 'Not Found', 'message': 'User not found'}), 404
+
+        lvl_count = db.query(func.count(CuratorLevel.level)).scalar()
+        if lvl_count == 0:
+            seed_badges_and_levels(db)
+
+        stats = _build_curator_stats(db, user)
+        return jsonify(stats), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500
+
+
+@curator_bp.route('/levels', methods=['GET'])
+def get_curator_levels():
+    """
+    Get all curator progression levels
+    ---
+    tags:
+      - Badges & Gamification
+    responses:
+      200:
+        description: List of all curator levels
+        schema:
+          type: object
+          properties:
+            levels:
+              type: array
+            total:
+              type: integer
+      400:
+        description: Bad request
+    """
+    try:
+        db = get_db()
+
+        lvl_count = db.query(func.count(CuratorLevel.level)).scalar()
+        if lvl_count == 0:
+            seed_badges_and_levels(db)
+
+        levels = db.query(CuratorLevel).order_by(CuratorLevel.level).all()
+        return jsonify({
+            'levels': [lvl.to_dict() for lvl in levels],
+            'total': len(levels),
+        }), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Internal Server Error', 'message': str(e)}), 500

--- a/backend/tests/test_badges.py
+++ b/backend/tests/test_badges.py
@@ -1,0 +1,350 @@
+"""
+Badges & Gamification Test Suite
+Tests all 6 endpoints:
+  GET /badges
+  GET /badges/user              (JWT required)
+  GET /badges/user/{userId}
+  GET /curator/stats            (JWT required)
+  GET /curator/stats/{userId}
+  GET /curator/levels
+
+Run with:
+    pytest tests/test_badges.py -v
+"""
+
+import pytest
+import requests
+import random
+import string
+
+BASE_URL = "http://localhost:3000/api/v1"
+
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+
+def random_suffix(n: int = 8) -> str:
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=n))
+
+
+def register_and_login() -> tuple[str, str]:
+    """Create a fresh user and return (token, user_id)."""
+    suffix = random_suffix()
+    payload = {
+        "email": f"badge_test_{suffix}@test.com",
+        "username": f"badger_{suffix}",
+        "password": "Test123456!",
+    }
+    r = requests.post(f"{BASE_URL}/auth/register", json=payload)
+    assert r.status_code == 201, f"Registration failed: {r.text}"
+    data = r.json()
+    token = data.get("token") or data.get("access_token") or data.get("accessToken")
+    user_id = data.get("userId") or data.get("user_id") or (data.get("user") or {}).get("userId")
+    assert token, f"No token in register response: {data}"
+    assert user_id, f"No userId in register response: {data}"
+    return token, user_id
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ─────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def user_credentials():
+    """Single user shared across the module tests."""
+    return register_and_login()
+
+
+@pytest.fixture(scope="module")
+def token(user_credentials):
+    return user_credentials[0]
+
+
+@pytest.fixture(scope="module")
+def user_id(user_credentials):
+    return user_credentials[1]
+
+
+# ─────────────────────────────────────────────
+# GET /badges
+# ─────────────────────────────────────────────
+
+class TestGetAllBadges:
+    def test_returns_200(self):
+        r = requests.get(f"{BASE_URL}/badges")
+        assert r.status_code == 200
+
+    def test_response_shape(self):
+        r = requests.get(f"{BASE_URL}/badges")
+        data = r.json()
+        assert "badges" in data
+        assert "total" in data
+        assert isinstance(data["badges"], list)
+        assert data["total"] == len(data["badges"])
+
+    def test_badges_seeded(self):
+        """At least 14 default badges should exist after seeding."""
+        r = requests.get(f"{BASE_URL}/badges")
+        data = r.json()
+        assert data["total"] >= 14, f"Expected >=14 badges, got {data['total']}"
+
+    def test_badge_fields(self):
+        r = requests.get(f"{BASE_URL}/badges")
+        badges = r.json()["badges"]
+        required = {"id", "name", "description", "icon", "rarity", "category", "maxProgress", "unlocked", "progress"}
+        for badge in badges:
+            missing = required - badge.keys()
+            assert not missing, f"Badge '{badge.get('name')}' missing fields: {missing}"
+
+    def test_filter_by_rarity(self):
+        for rarity in ["common", "rare", "epic", "legendary"]:
+            r = requests.get(f"{BASE_URL}/badges", params={"rarity": rarity})
+            assert r.status_code == 200, f"rarity={rarity} failed"
+            badges = r.json()["badges"]
+            for b in badges:
+                assert b["rarity"] == rarity, f"Unexpected rarity {b['rarity']}"
+
+    def test_filter_by_category(self):
+        for cat in ["early", "completionist", "social", "streak", "special"]:
+            r = requests.get(f"{BASE_URL}/badges", params={"category": cat})
+            assert r.status_code == 200, f"category={cat} failed"
+            badges = r.json()["badges"]
+            for b in badges:
+                assert b["category"] == cat
+
+    def test_invalid_rarity_returns_400(self):
+        r = requests.get(f"{BASE_URL}/badges", params={"rarity": "mythic"})
+        assert r.status_code == 400
+
+    def test_invalid_category_returns_400(self):
+        r = requests.get(f"{BASE_URL}/badges", params={"category": "nonsense"})
+        assert r.status_code == 400
+
+
+# ─────────────────────────────────────────────
+# GET /badges/user  (JWT required)
+# ─────────────────────────────────────────────
+
+class TestGetCurrentUserBadges:
+    def test_requires_auth(self):
+        r = requests.get(f"{BASE_URL}/badges/user")
+        assert r.status_code == 401
+
+    def test_returns_200_with_auth(self, token):
+        r = requests.get(f"{BASE_URL}/badges/user", headers=auth_header(token))
+        assert r.status_code == 200
+
+    def test_response_shape(self, token):
+        r = requests.get(f"{BASE_URL}/badges/user", headers=auth_header(token))
+        data = r.json()
+        assert "badges" in data
+        assert "earnedCount" in data
+        assert "totalCount" in data
+
+    def test_total_matches_badge_catalog(self, token):
+        """totalCount should equal the number of badges in the catalog."""
+        all_r = requests.get(f"{BASE_URL}/badges")
+        user_r = requests.get(f"{BASE_URL}/badges/user", headers=auth_header(token))
+        assert user_r.json()["totalCount"] == all_r.json()["total"]
+
+    def test_new_user_has_no_share_dependent_badges(self, token):
+        r = requests.get(f"{BASE_URL}/badges/user", headers=auth_header(token))
+        data = r.json()
+        # Share-dependent badges (Film Buff, 7-Day Streak, etc.) must not be
+        # unlocked for a brand-new user with zero shares.
+        # Note: "Early Adopter" is intentionally auto-unlocked for beta users.
+        share_dependent = {
+            "Film Buff", "Audiophile", "Bookworm", "Gamer", "Wanderer",
+            "All-Rounder", "Social Butterfly", "Trendsetter",
+            "7-Day Streak", "30-Day Streak", "Tastemaker", "Legend",
+        }
+        for badge in data["badges"]:
+            if badge["name"] in share_dependent:
+                assert not badge["unlocked"], (
+                    f"Badge '{badge['name']}' should not be unlocked for a new user"
+                )
+
+    def test_badge_progress_fields(self, token):
+        r = requests.get(f"{BASE_URL}/badges/user", headers=auth_header(token))
+        for b in r.json()["badges"]:
+            assert "progress" in b
+            assert "maxProgress" in b
+            assert "unlocked" in b
+            assert isinstance(b["unlocked"], bool)
+
+
+# ─────────────────────────────────────────────
+# GET /badges/user/{userId}
+# ─────────────────────────────────────────────
+
+class TestGetUserBadgesById:
+    def test_valid_user(self, user_id):
+        r = requests.get(f"{BASE_URL}/badges/user/{user_id}")
+        assert r.status_code == 200
+
+    def test_response_includes_username(self, user_id):
+        r = requests.get(f"{BASE_URL}/badges/user/{user_id}")
+        data = r.json()
+        assert "userId" in data
+        assert "username" in data
+        assert data["userId"] == user_id
+
+    def test_response_shape(self, user_id):
+        r = requests.get(f"{BASE_URL}/badges/user/{user_id}")
+        data = r.json()
+        assert "badges" in data
+        assert "earnedCount" in data
+        assert "totalCount" in data
+
+    def test_unknown_user_returns_404(self):
+        r = requests.get(f"{BASE_URL}/badges/user/u_nonexistentXXXX")
+        assert r.status_code == 404
+
+
+# ─────────────────────────────────────────────
+# GET /curator/stats  (JWT required)
+# ─────────────────────────────────────────────
+
+class TestGetCuratorStats:
+    def test_requires_auth(self):
+        r = requests.get(f"{BASE_URL}/curator/stats")
+        assert r.status_code == 401
+
+    def test_returns_200_with_auth(self, token):
+        r = requests.get(f"{BASE_URL}/curator/stats", headers=auth_header(token))
+        assert r.status_code == 200
+
+    def test_response_fields(self, token):
+        r = requests.get(f"{BASE_URL}/curator/stats", headers=auth_header(token))
+        data = r.json()
+        required = {
+            "userId", "username", "totalShares", "totalXP",
+            "currentLevel", "currentLevelName", "xpToNextLevel",
+            "streakDays", "categoryBreakdown", "badges", "badgeCount",
+        }
+        missing = required - data.keys()
+        assert not missing, f"Missing fields: {missing}"
+
+    def test_new_user_starts_at_level_1(self, token):
+        r = requests.get(f"{BASE_URL}/curator/stats", headers=auth_header(token))
+        data = r.json()
+        assert data["currentLevel"] == 1
+        assert data["totalShares"] == 0
+        assert data["totalXP"] == 0
+
+    def test_xp_calculation_after_share(self, token, user_id):
+        """Create a share then verify XP goes up by 10."""
+        # First, get a real content id from the movies endpoint
+        movies_r = requests.get(f"{BASE_URL}/content/movies", params={"limit": 1})
+        movie_id = None
+        if movies_r.status_code == 200 and movies_r.json().get("movies"):
+            movie_id = movies_r.json()["movies"][0]["id"]
+
+        share_payload = {
+            "category": "cinema",
+            "contentId": movie_id or "tt0111161",
+            "title": "Test Movie Share",
+            "caption": "badge test share",
+        }
+        share_r = requests.post(
+            f"{BASE_URL}/aura/shares",
+            json=share_payload,
+            headers=auth_header(token),
+        )
+        if share_r.status_code not in (200, 201):
+            pytest.skip(f"Share creation returned {share_r.status_code}; skipping XP test")
+
+        stats_r = requests.get(f"{BASE_URL}/curator/stats", headers=auth_header(token))
+        data = stats_r.json()
+        assert data["totalShares"] >= 1
+        assert data["totalXP"] >= 10
+
+    def test_streak_days_is_integer(self, token):
+        r = requests.get(f"{BASE_URL}/curator/stats", headers=auth_header(token))
+        assert isinstance(r.json()["streakDays"], int)
+
+
+# ─────────────────────────────────────────────
+# GET /curator/stats/{userId}
+# ─────────────────────────────────────────────
+
+class TestGetCuratorStatsByUserId:
+    def test_valid_user(self, user_id):
+        r = requests.get(f"{BASE_URL}/curator/stats/{user_id}")
+        assert r.status_code == 200
+
+    def test_response_has_all_fields(self, user_id):
+        r = requests.get(f"{BASE_URL}/curator/stats/{user_id}")
+        data = r.json()
+        required = {"userId", "username", "totalShares", "totalXP", "currentLevel"}
+        missing = required - data.keys()
+        assert not missing, f"Missing fields: {missing}"
+
+    def test_user_id_matches(self, user_id):
+        r = requests.get(f"{BASE_URL}/curator/stats/{user_id}")
+        assert r.json()["userId"] == user_id
+
+    def test_unknown_user_returns_404(self):
+        r = requests.get(f"{BASE_URL}/curator/stats/u_nonexistentXXXX")
+        assert r.status_code == 404
+
+
+# ─────────────────────────────────────────────
+# GET /curator/levels
+# ─────────────────────────────────────────────
+
+class TestGetCuratorLevels:
+    def test_returns_200(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        assert r.status_code == 200
+
+    def test_response_shape(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        data = r.json()
+        assert "levels" in data
+        assert "total" in data
+        assert isinstance(data["levels"], list)
+
+    def test_ten_levels_seeded(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        data = r.json()
+        assert data["total"] == 10, f"Expected 10 levels, got {data['total']}"
+
+    def test_level_fields(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        for lvl in r.json()["levels"]:
+            assert "level" in lvl
+            assert "name" in lvl
+            assert "xpRequired" in lvl
+            assert "rewards" in lvl
+            assert "color" in lvl
+            assert isinstance(lvl["rewards"], list)
+
+    def test_levels_ordered_ascending(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        levels = r.json()["levels"]
+        nums = [l["level"] for l in levels]
+        assert nums == sorted(nums), f"Levels not sorted: {nums}"
+
+    def test_xp_required_increases(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        levels = r.json()["levels"]
+        xp_vals = [l["xpRequired"] for l in levels]
+        assert xp_vals == sorted(xp_vals), f"XP not increasing: {xp_vals}"
+
+    def test_first_level_requires_zero_xp(self):
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        first = r.json()["levels"][0]
+        assert first["xpRequired"] == 0
+
+    def test_color_is_hex(self):
+        import re
+        hex_re = re.compile(r"^#[0-9A-Fa-f]{6}$")
+        r = requests.get(f"{BASE_URL}/curator/levels")
+        for lvl in r.json()["levels"]:
+            assert hex_re.match(lvl["color"]), f"Bad color: {lvl['color']}"


### PR DESCRIPTION
Introduce Badge, UserBadge, and CuratorLevel models with seed data and a seeding helper; register badge/curator blueprints and add routes for badge catalog, user badge endpoints, and curator stats/levels. Update database initialization to import the new badge model and update models package exports. Add comprehensive integration tests for all badges and curator endpoints and update .gitignore to ignore pytest and venv artifacts.